### PR TITLE
change from_json test

### DIFF
--- a/src/__pytest__/test_adapter.py
+++ b/src/__pytest__/test_adapter.py
@@ -3,18 +3,14 @@ import json
 
 from src.adapter import Adapter
 
-@pytest.mark.parametrize("test_dict", [
-    (None),
-    ({}),
-])
-def test_adapter_from_json_deserializes_options_for_creator(test_dict):
-    expected_options_dict = test_dict
-    serialized_test_json = json.dumps(expected_options_dict)
+# Should be changed to get a json string as input, when options gets a clear usecase
+def test_adapter_from_json_deserializes_empty_options_for_creator():
+    serialized_test_json = json.dumps({})
     adapter = Adapter()
 
     deserialized_options = adapter.from_json(serialized_test_json)
 
-    assert deserialized_options == expected_options_dict
+    assert {} == deserialized_options
 
 def test_adapter_to_json_serializes_grouping_1_to_traffic_model_schema(fake_mapdata_node_1, fake_mapdata_edge_1, fake_expected_model_1):
     adapter = Adapter()


### PR DESCRIPTION
I had to merge into master and then redo a new pull request, since without the gitignore being applied, there were 1444 files to traverse in the adapter_env folder (!!!!!!!) making it sort of impossible to find the adapter file and test files.... Hope its ok!

The to_json test does not pass, and it is probably due to the following concerns

**Concerns and Changes**

dictionaries CANNOT access their items through dot notation apparently. use the model["nodes"] syntax.
(I think it has to do with dot notation accessing attributes of the dictionary "class" making it not work on contained values)
By just changing the nodes to the new syntax, they are correct in the test (however, edges still fail)

fixtures in conftest has been updated to follow the new assumption (each road consists of two edges)

Remember that the adapter only gets table data as input. Weights, error_list, etc. should be set to a default value
(as they are not part of a database entry)

i made a "win_env" since apparently the mac installation ruined the windows one... There is a fix, but its not worth the effort to fix right now (we have more pressing concerns)

**Suggestion**
In general, i will suggest to run pytest as a command often.

And then i have a suggestion, that each edge should NOT have its own unique ID.
consider the following

model["nodes"][node_one]["edges"][node_two]

This gives the road, connecting from node one to node two, uniquely identifying it.
However, if the edge has an id of, for instance 5, this value cannot be queried by our model, other than by making two consecutive for loops (we have no idea where the "5." edge is in our list of nodes)

As such, i believe we have a fine primary key, consisting of two nodes giving a unique road, and that giving each road an id would only give an overhead, which would never be used in the best case, and would give rise to anti-patterns in the worst (querying two for loops for instance)

I'm open for counterarguments, but would like to be presented with a query using the edge_id, if there still is insistance for the id.